### PR TITLE
Fix writing to temporary directory

### DIFF
--- a/allowARMv2.ps1
+++ b/allowARMv2.ps1
@@ -1,4 +1,4 @@
-$sussyFile = "C:\Temp\allowARM_ms_store.reg"
+$sussyFile = "${env:TEMP}\allowARM_ms_store.reg"
 $regBaka = @"
 Windows Registry Editor Version 5.00
 


### PR DESCRIPTION
On a fresh installation of Windows 11 Home edition, the directory `C:\Temp` does not exist and the script fails. However, the `TEMP` environment variable points to an existing directory meant to store temporary files.

The default TEMP value seems to be: `C:\Users\MYUSER\AppData\Local\Temp`